### PR TITLE
mc-9607 Detect enumeration values

### DIFF
--- a/dockerfile/fixtures/create_metadata_simple.sql
+++ b/dockerfile/fixtures/create_metadata_simple.sql
@@ -85,3 +85,55 @@ CREATE INDEX IF NOT EXISTS metadata_catalogue_item_idx
 CREATE INDEX IF NOT EXISTS metadata_created_by_idx
     ON metadata(created_by_id);
 
+CREATE TABLE organisation
+(
+  id INT NOT NULL PRIMARY KEY,
+  org_name VARCHAR(255) NOT NULL,
+  org_type VARCHAR(20) NOT NULL,
+  org_code VARCHAR(15) NOT NULL,
+  description VARCHAR,
+  org_char CHAR(5)
+);
+--Use both VARCHAR and CHAR columns. Expect that because there are no CHAR columns other than org_char,
+--when org_char is detected as an enumeration, CHAR will be removed from the primitive data types
+INSERT INTO organisation(id, org_name, org_type, org_code, description, org_char) VALUES
+(1, 'ORG1', 'TYPEA', 'CODEY', 'Description of ORG1', 'CHAR1'),
+(2, 'ORG2', 'TYPEA', 'CODEY', 'Description of ORG2', 'CHAR1'),
+(3, 'ORG3', 'TYPEA', 'CODEY', 'Description of ORG3', 'CHAR1'),
+(4, 'ORG4', 'TYPEA', 'CODEY', 'Description of ORG4', 'CHAR1'),
+(5, 'ORG5', 'TYPEB', 'CODEY', 'Description of ORG5', 'CHAR1'),
+(6, 'ORG6', 'TYPEB', 'CODEY', 'Description of ORG6', 'CHAR1'),
+(7, 'ORG7', 'TYPEB', 'CODEY', 'Description of ORG7', 'CHAR1'),
+(8, 'ORG8', 'TYPEB', 'CODEY', 'Description of ORG8', 'CHAR2'),
+(9, 'ORG9', 'TYPEB', 'CODEY', 'Description of ORG9', 'CHAR2'),
+(10, 'ORG10', 'TYPEA', 'CODEZ', 'Description of ORG10', 'CHAR2'),
+(11, 'ORG11', 'TYPEA', 'CODEZ', 'Description of ORG11', 'CHAR2'),
+(12, 'ORG12', 'TYPEA', 'CODEZ', 'Description of ORG12', 'CHAR2'),
+(13, 'ORG13', 'TYPEA', 'CODEZ', 'Description of ORG13', 'CHAR2'),
+(14, 'ORG14', 'TYPEA', 'CODEZ', 'Description of ORG14', 'CHAR2'),
+(15, 'ORG15', 'TYPEB', 'CODEZ', 'Description of ORG15', 'CHAR2'),
+(16, 'ORG16', 'TYPEB', 'CODEZ', 'Description of ORG16', 'CHAR2'),
+(17, 'ORG17', 'TYPEB', 'CODEZ', 'Description of ORG17', 'CHAR2'),
+(18, 'ORG18', 'TYPEB', 'CODEZ', 'Description of ORG18', 'CHAR2'),
+(19, 'ORG19', 'TYPEB', 'CODEZ', 'Description of ORG19', 'CHAR2'),
+(20, 'ORG20', 'TYPEB', 'CODEZ', 'Description of ORG20', 'CHAR2'),
+(21, 'ORG21', 'TYPEA', 'CODEX', 'Description of ORG21', 'CHAR3'),
+(22, 'ORG22', 'TYPEA', 'CODEX', 'Description of ORG22', 'CHAR3'),
+(23, 'ORG23', 'TYPEA', 'CODEX', 'Description of ORG23', 'CHAR3'),
+(24, 'ORG24', 'TYPEA', 'CODEX', 'Description of ORG24', 'CHAR3'),
+(25, 'ORG25', 'TYPEB', 'CODEX', 'Description of ORG25', 'CHAR3'),
+(26, 'ORG26', 'TYPEB', 'CODEX', 'Description of ORG26', 'CHAR3'),
+(27, 'ORG27', 'TYPEB', 'CODEX', 'Description of ORG27', 'CHAR3'),
+(28, 'ORG28', 'TYPEB', 'CODEX', 'Description of ORG28', 'CHAR3'),
+(29, 'ORG29', 'TYPEB', 'CODEX', 'Description of ORG29', 'CHAR3'),
+(30, 'ORG30', 'TYPEB', 'CODEX', 'Description of ORG30', 'CHAR3'),
+(31, 'ORG31', 'TYPEA', 'CODEX', 'Description of ORG31', 'CHAR3'),
+(32, 'ORG32', 'TYPEA', 'CODEX', 'Description of ORG32', 'CHAR3'),
+(33, 'ORG33', 'TYPEA', 'CODEX', 'Description of ORG33', 'CHAR3'),
+(34, 'ORG34', 'TYPEA', 'CODEX', 'Description of ORG34', 'CHAR3'),
+(35, 'ORG35', 'TYPEC', 'CODEX', 'Description of ORG35', 'CHAR3'),
+(36, 'ORG36', 'TYPEC', 'CODEX', 'Description of ORG36', 'CHAR3'),
+(37, 'ORG37', 'TYPEB', 'CODEX', 'Description of ORG37', 'CHAR3'),
+(38, 'ORG38', 'TYPEB', 'CODEX', 'Description of ORG38', 'CHAR3'),
+(39, 'ORG39', 'TYPEB', 'CODEX', 'Description of ORG39', 'CHAR3'),
+(40, 'ORG40', 'TYPEB', 'CODER', 'Description of ORG40', 'CHAR3');

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/postgres/PostgresDatabaseDataModelImporterProviderServiceTest.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/postgres/PostgresDatabaseDataModelImporterProviderServiceTest.groovy
@@ -20,6 +20,7 @@ package uk.ac.ox.softeng.maurodatamapper.plugins.database.postgres
 import uk.ac.ox.softeng.maurodatamapper.core.facet.Metadata
 import uk.ac.ox.softeng.maurodatamapper.datamodel.DataModel
 import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.EnumerationType
 import uk.ac.ox.softeng.maurodatamapper.plugins.testing.utils.BaseDatabasePluginTest
 
 import groovy.json.JsonSlurper
@@ -27,6 +28,7 @@ import org.junit.Test
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 
 // @CompileStatic
@@ -57,14 +59,16 @@ class PostgresDatabaseDataModelImporterProviderServiceTest extends BaseDatabaseP
         final DataModel dataModel = importDataModelAndRetrieveFromDatabase(
             createDatabaseImportParameters(databaseHost, databasePort).tap {databaseNames = 'metadata_simple'})
         assertEquals 'Database/Model name', 'metadata_simple', dataModel.label
-        assertEquals 'Number of columntypes/datatypes', 10, dataModel.dataTypes?.size()
-        assertEquals 'Number of primitive types', 8, dataModel.dataTypes.findAll {it.domainType == 'PrimitiveType'}.size()
+        assertEquals 'Number of columntypes/datatypes', 11, dataModel.dataTypes?.size()
+        assertEquals 'Number of primitive types', 9, dataModel.dataTypes.findAll {it.domainType == 'PrimitiveType'}.size()
         assertEquals 'Number of reference types', 2, dataModel.dataTypes.findAll {it.domainType == 'ReferenceType'}.size()
-        assertEquals 'Number of tables/dataclasses', 4, dataModel.dataClasses?.size()
+        assertEquals 'Number of enumeration types', 0, dataModel.dataTypes.findAll {it.domainType == 'EnumerationType'}.size()
+        assertEquals 'Number of char datatypes', 1, dataModel.dataTypes.findAll {it.domainType == 'PrimitiveType' && it.label == 'character'}.size()
+        assertEquals 'Number of tables/dataclasses', 5, dataModel.dataClasses?.size()
         assertEquals 'Number of child tables/dataclasses', 1, dataModel.childDataClasses?.size()
 
         final DataClass publicSchema = dataModel.childDataClasses.first()
-        assertEquals 'Number of child tables/dataclasses', 3, publicSchema.dataClasses?.size()
+        assertEquals 'Number of child tables/dataclasses', 4, publicSchema.dataClasses?.size()
 
         final Set<DataClass> dataClasses = publicSchema.dataClasses
 
@@ -127,5 +131,133 @@ class PostgresDatabaseDataModelImporterProviderServiceTest extends BaseDatabaseP
         assertEquals 'CI mandatory elements', 9, ciTable.dataElements.count {it.minMultiplicity == 1}
         assertEquals 'CI optional element description', 0, ciTable.findDataElement('description').minMultiplicity
         assertEquals 'CU mandatory elements', 10, cuTable.dataElements.count {it.minMultiplicity == 1}
+
+        final DataClass organisationTable = dataClasses.find {it.label == 'organisation'}
+        assertEquals 'Organisation Number of columns/dataElements', 6, organisationTable.dataElements.size()
+        // Expect 3 metadata - 2 for the primary key and 1 for indexes
+        assertEquals 'Organisation Number of metadata', 3, organisationTable.metadata.size()
+        //Expect all types to be Primitive, because we are not detecting enumerations
+        assertEquals 'DomainType of the DataType for org_code', 'PrimitiveType', organisationTable.findDataElement('org_code').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_name', 'PrimitiveType', organisationTable.findDataElement('org_name').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_char', 'PrimitiveType', organisationTable.findDataElement('org_char').dataType.domainType
+        assertEquals 'DomainType of the DataType for description', 'PrimitiveType', organisationTable.findDataElement('description').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_type', 'PrimitiveType', organisationTable.findDataElement('org_type').dataType.domainType
+        assertEquals 'DomainType of the DataType for id', 'PrimitiveType', organisationTable.findDataElement('id').dataType.domainType
+    }
+
+    @Test
+    void testImportSimpleDatabaseWithEnumerations() {
+        final DataModel dataModel = importDataModelAndRetrieveFromDatabase(
+                createDatabaseImportParameters(databaseHost, databasePort).tap {
+                    databaseNames = 'metadata_simple';
+                    detectEnumerations = true;
+                    maxEnumerations = 20})
+        assertEquals 'Database/Model name', 'metadata_simple', dataModel.label
+        assertEquals 'Number of columntypes/datatypes', 13, dataModel.dataTypes?.size()
+        assertEquals 'Number of primitive types', 8, dataModel.dataTypes.findAll {it.domainType == 'PrimitiveType'}.size()
+        assertEquals 'Number of reference types', 2, dataModel.dataTypes.findAll {it.domainType == 'ReferenceType'}.size()
+        assertEquals 'Number of enumeration types', 3, dataModel.dataTypes.findAll {it.domainType == 'EnumerationType'}.size()
+        assertEquals 'Number of char datatypes', 0, dataModel.dataTypes.findAll {it.domainType == 'PrimitiveType' && it.label == 'character'}.size()
+        assertEquals 'Number of tables/dataclasses', 5, dataModel.dataClasses?.size()
+        assertEquals 'Number of child tables/dataclasses', 1, dataModel.childDataClasses?.size()
+
+        final DataClass publicSchema = dataModel.childDataClasses.first()
+        assertEquals 'Number of child tables/dataclasses', 4, publicSchema.dataClasses?.size()
+
+        final Set<DataClass> dataClasses = publicSchema.dataClasses
+
+        // Tables
+        final DataClass metadataTable = dataClasses.find {it.label == 'metadata'}
+        assertEquals 'Metadata Number of columns/dataElements', 10, metadataTable.dataElements.size()
+        assertEquals 'Metadata Number of metadata', 3, metadataTable.metadata.size()
+
+        assertTrue 'MD All metadata values are valid', metadataTable.metadata.every {it.value && it.key != it.value}
+
+        List<Map> indexesInfo = new JsonSlurper().parseText(metadataTable.metadata.find {it.key == 'indexes'}.value) as List<Map>
+
+        assertEquals('MD Index count', 4, indexesInfo.size())
+
+        assertEquals 'MD Primary key', 1, metadataTable.metadata.count {it.key == 'primary_key_name'}
+        assertEquals 'MD Primary key', 1, metadataTable.metadata.count {it.key == 'primary_key_columns'}
+        assertEquals 'MD Primary indexes', 1, indexesInfo.findAll {it.primaryIndex}.size()
+        assertEquals 'MD Unique indexes', 2, indexesInfo.findAll {it.uniqueIndex}.size()
+        assertEquals 'MD indexes', 2, indexesInfo.findAll {!it.uniqueIndex && !it.primaryIndex}.size()
+
+        final Map multipleColIndex =indexesInfo.find {it.name ==  'unique_item_id_namespace_key'}
+        assertNotNull 'Should have multi column index', multipleColIndex
+        assertEquals 'Correct order of columns', 'catalogue_item_id, namespace, key', multipleColIndex.columns
+
+        final DataClass ciTable = dataClasses.find {it.label == 'catalogue_item'}
+        assertEquals 'CI Number of columns/dataElements', 10, ciTable.dataElements.size()
+        assertEquals 'CI Number of metadata', 3, ciTable.metadata.size()
+
+        assertTrue 'CI All metadata values are valid', ciTable.metadata.every {it.value && it.key != it.value}
+
+        indexesInfo = new JsonSlurper().parseText(ciTable.metadata.find {it.key == 'indexes'}.value) as List<Map>
+
+        assertEquals('CI Index count', 3, indexesInfo.size())
+
+        assertEquals 'CI Primary key', 1, ciTable.metadata.count {it.key == 'primary_key_name'}
+        assertEquals 'CI Primary key', 1, ciTable.metadata.count {it.key == 'primary_key_columns'}
+        assertEquals 'CI Primary indexes', 1, indexesInfo.findAll {it.primaryIndex}.size()
+        assertEquals 'CI indexes', 2, indexesInfo.findAll {!it.uniqueIndex && !it.primaryIndex}.size()
+
+        final DataClass cuTable = dataClasses.find {it.label == 'catalogue_user'}
+        assertEquals 'CU Number of columns/dataElements', 18, cuTable.dataElements.size()
+        assertEquals 'CU Number of metadata', 5, cuTable.metadata.size()
+
+        assertTrue 'CU All metadata values are valid', cuTable.metadata.every {it.value && it.key != it.value}
+
+        indexesInfo = new JsonSlurper().parseText(cuTable.metadata.find {it.key == 'indexes'}.value) as List<Map>
+
+        assertEquals('CU Index count', 3, indexesInfo.size())
+
+        assertEquals 'CU Primary key', 1, cuTable.metadata.count {it.key == 'primary_key_name'}
+        assertEquals 'CU Primary key', 1, cuTable.metadata.count {it.key == 'primary_key_columns'}
+        assertEquals 'CI Primary indexes', 1, indexesInfo.findAll {it.primaryIndex}.size()
+        assertEquals 'CI Unique indexes', 2, indexesInfo.findAll {it.uniqueIndex}.size()
+        assertEquals 'CI indexes', 1, indexesInfo.findAll {!it.uniqueIndex && !it.primaryIndex}.size()
+        assertEquals 'CU constraint', 1, cuTable.metadata.count {it.key == 'unique_name'}
+        assertEquals 'CU constraint', 1, cuTable.metadata.count {it.key == 'unique_columns'}
+
+        // Columns
+        assertTrue 'Metadata all elements required', metadataTable.dataElements.every {it.minMultiplicity == 1}
+        assertEquals 'CI mandatory elements', 9, ciTable.dataElements.count {it.minMultiplicity == 1}
+        assertEquals 'CI optional element description', 0, ciTable.findDataElement('description').minMultiplicity
+        assertEquals 'CU mandatory elements', 10, cuTable.dataElements.count {it.minMultiplicity == 1}
+
+        final DataClass organisationTable = dataClasses.find {it.label == 'organisation'}
+        assertEquals 'Organisation Number of columns/dataElements', 6, organisationTable.dataElements.size()
+        // Expect 3 metadata - 2 for the primary key and 1 for indexes
+        assertEquals 'Organisation Number of metadata', 3, organisationTable.metadata.size()
+        //Expect all types to be Primitive, because we are not detecting enumerations
+        assertEquals 'DomainType of the DataType for org_code', 'EnumerationType', organisationTable.findDataElement('org_code').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_name', 'PrimitiveType', organisationTable.findDataElement('org_name').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_char', 'EnumerationType', organisationTable.findDataElement('org_char').dataType.domainType
+        assertEquals 'DomainType of the DataType for description', 'PrimitiveType', organisationTable.findDataElement('description').dataType.domainType
+        assertEquals 'DomainType of the DataType for org_type', 'EnumerationType', organisationTable.findDataElement('org_type').dataType.domainType
+        assertEquals 'DomainType of the DataType for id', 'PrimitiveType', organisationTable.findDataElement('id').dataType.domainType
+
+        final EnumerationType orgCodeEnumerationType = organisationTable.findDataElement('org_code').dataType
+        assertEquals 'Number of enumeration values for org_code', 4, orgCodeEnumerationType.enumerationValues.size()
+        assertNotNull 'Enumeration value found', orgCodeEnumerationType.enumerationValues.find{it.key == 'CODEZ'}
+        assertNotNull 'Enumeration value found',orgCodeEnumerationType.enumerationValues.find{it.key == 'CODEY'}
+        assertNotNull 'Enumeration value found',orgCodeEnumerationType.enumerationValues.find{it.key == 'CODEX'}
+        assertNotNull 'Enumeration value found',orgCodeEnumerationType.enumerationValues.find{it.key == 'CODER'}
+        assertNull 'Not an expected value', orgCodeEnumerationType.enumerationValues.find{it.key == 'CODEP'}
+
+        final EnumerationType orgTypeEnumerationType = organisationTable.findDataElement('org_type').dataType
+        assertEquals 'Number of enumeration values for org_type', 3, orgTypeEnumerationType.enumerationValues.size()
+        assertNotNull 'Enumeration value found', orgTypeEnumerationType.enumerationValues.find{it.key == 'TYPEA'}
+        assertNotNull 'Enumeration value found', orgTypeEnumerationType.enumerationValues.find{it.key == 'TYPEB'}
+        assertNotNull 'Enumeration value found', orgTypeEnumerationType.enumerationValues.find{it.key == 'TYPEC'}
+        assertNull 'Not an expected value', orgTypeEnumerationType.enumerationValues.find{it.key == 'TYPEZ'}
+
+        final EnumerationType orgCharEnumerationType = organisationTable.findDataElement('org_char').dataType
+        assertEquals 'Number of enumeration values for org_char', 3, orgCharEnumerationType.enumerationValues.size()
+        assertNotNull 'Enumeration value found', orgCharEnumerationType.enumerationValues.find{it.key == 'CHAR1'}
+        assertNotNull 'Enumeration value found', orgCharEnumerationType.enumerationValues.find{it.key == 'CHAR2'}
+        assertNotNull 'Enumeration value found', orgCharEnumerationType.enumerationValues.find{it.key == 'CHAR3'}
+        assertNull 'Not an expected value', orgCharEnumerationType.enumerationValues.find{it.key == 'CHAR4'}
     }
 }

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/postgres/PostgresDatabaseDataModelImporterProviderService.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/database/postgres/PostgresDatabaseDataModelImporterProviderService.groovy
@@ -17,6 +17,7 @@
  */
 package uk.ac.ox.softeng.maurodatamapper.plugins.database.postgres
 
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.datatype.DataType
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.AbstractDatabaseDataModelImporterProviderService
 import uk.ac.ox.softeng.maurodatamapper.plugins.database.RemoteDatabaseDataModelImporterProviderService
 
@@ -115,6 +116,23 @@ class PostgresDatabaseDataModelImporterProviderService
         FROM information_schema.columns
         WHERE table_schema NOT IN ('pg_catalog','information_schema');
         '''.stripIndent()
+    }
+
+    //PostgreSQL quote escaping of identifiers
+    @Override
+    String countDistinctColumnValuesQueryString(String tableName, String columnName) {
+        "SELECT COUNT(DISTINCT(\"${columnName}\")) AS count FROM \"${tableName}\";"
+    }
+
+    //PostgreSQL quote escaping of identifiers
+    @Override
+    String distinctColumnValuesQueryString(String tableName, String columnName) {
+        "SELECT DISTINCT(\"${columnName}\") AS distinct_value FROM \"${tableName}\";"
+    }
+
+    @Override
+    boolean isColumnPossibleEnumeration(DataType dataType) {
+        dataType.domainType == 'PrimitiveType' && (dataType.label == "character" || dataType.label == "character varying")
     }
 
     @Override


### PR DESCRIPTION
Add detection of enumeration values.

Depends on the corresponding pull request in mdm-plugin-database.

Override the base functions with PostgreSQL specific escaping and column types.

And test data and tests for cases where enumeration detection is switched off (default) and on.